### PR TITLE
Added most_downloaded to consume corresponding api method to get most dow

### DIFF
--- a/lib/gems/client.rb
+++ b/lib/gems/client.rb
@@ -69,6 +69,17 @@ module Gems
       YAML.load(response)
     end
 
+    # Returns an array of the most downloaded gem versions of all time
+    #
+    # @authenticated false
+    # @return [Hash]
+    # @example
+    #   Gems.most_downloaded
+    def most_downloaded
+      response = get("/api/v1/downloads/all.yaml")
+      YAML.load(response)
+    end
+
     # Returns the number of downloads by day for a particular gem version
     #
     # @authenticated false

--- a/spec/fixtures/most_downloaded.yaml
+++ b/spec/fixtures/most_downloaded.yaml
@@ -1,0 +1,20 @@
+--- 
+:gems: 
+- - position: 0
+    number: 1.0.0
+    built_at: 2006-03-12 15:00:00 Z
+    created_at: 2011-09-16 23:01:28.426563 Z
+    updated_at: 2011-09-16 23:01:28.426563 Z
+    indexed: true
+    id: 86
+    prerelease: false
+    full_name: abstract-1.0.0
+    summary: a library which enable you to define abstract method in Ruby
+    description: "'abstract.rb' is a library which enable you to define abstract method in Ruby."
+    authors: makoto kuwata
+    rubygem_id: 86
+    rubyforge_project: 
+    latest: true
+    downloads_count: 0
+    platform: ruby
+  - 1

--- a/spec/gems/client_spec.rb
+++ b/spec/gems/client_spec.rb
@@ -100,6 +100,23 @@ describe Gems::Client do
 
   end
 
+  describe ".most_downloaded" do
+    context "with nothing specified" do
+      before do
+        stub_get("/api/v1/downloads/all.yaml").
+	  to_return(:body => fixture("most_downloaded.yaml"))
+      end
+
+      it "should return the most downloaded versions" do
+        most_downloaded = Gems.most_downloaded
+        a_get("/api/v1/downloads/all.yaml").
+          should have_been_made
+        most_downloaded[:gems].first.first['full_name'].should == "abstract-1.0.0"
+        most_downloaded[:gems].first[1].should == 1
+      end
+    end
+  end
+
   describe ".downloads" do
 
     context "with no dates or version specified" do


### PR DESCRIPTION
Added most_downloaded to consume corresponding api method to get most downloaded gem versions of all time.

See [here](https://github.com/rubygems/rubygems.org/pull/347) for the new api method.
