### PR TITLE
Follow 302 redirects

### DIFF
--- a/lib/gems/request.rb
+++ b/lib/gems/request.rb
@@ -52,7 +52,7 @@ module Gems
       when Net::HTTPSuccess
         response.body
       when Net::HTTPRedirection
-        request(method, path, data, content_type, 'https://bundler.rubygems.org')
+        request(method, path, data, content_type, response['location'])
       end
     end
 


### PR DESCRIPTION
fixes #10, the request method was not following 302 redirects causing an HTTP status code to be returned rather than marshaled data
