### PR TITLE
Specify Ruby 2.2.0 support in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ implementations:
 * Ruby 1.9.3
 * Ruby 2.0.0
 * Ruby 2.1.0
+* Ruby 2.2.0
 * [JRuby][]
 * [Rubinius][]
 


### PR DESCRIPTION
Ruby 2.2.0 is already tested via Travis but it is not yet specified in the ReadMe.