### PR TITLE
Update webhooks documentation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,11 +59,11 @@ EmptyLinesAroundAccessModifier:
 
 # Align ends correctly
 EndAlignment:
-  AlignWith: variable
+  EnforcedStyleAlignWith: variable
 
 # Indentation of when/else
 CaseIndentation:
-  IndentWhenRelativeTo: end
+  EnforcedStyle: end
   IndentOneStep: false
 
 Lambda:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+before_install: gem update --system
 bundler_args: --without development
 cache: bundler
 env:

--- a/lib/gems/client.rb
+++ b/lib/gems/client.rb
@@ -207,7 +207,7 @@ module Gems
     # Create a webhook
     #
     # @authenticated true
-    # @param gem_name [String] The name of a gem. Specify "*" to add the hook to all your gems.
+    # @param gem_name [String] The name of a gem. Specify "*" to add the hook to all gems.
     # @param url [String] The URL of the web hook.
     # @return [String]
     # @example
@@ -219,7 +219,7 @@ module Gems
     # Remove a webhook
     #
     # @authenticated true
-    # @param gem_name [String] The name of a gem. Specify "*" to remove the hook from all your gems.
+    # @param gem_name [String] The name of a gem. Specify "*" to remove the hook from all gems.
     # @param url [String] The URL of the web hook.
     # @return [String]
     # @example
@@ -231,7 +231,7 @@ module Gems
     # Test fire a webhook
     #
     # @authenticated true
-    # @param gem_name [String] The name of a gem. Specify "*" to fire the hook for all your gems.
+    # @param gem_name [String] The name of a gem. Specify "*" to fire the hook for all gems.
     # @param url [String] The URL of the web hook.
     # @return [String]
     # @example


### PR DESCRIPTION
Hi, thanks for the great gem!

It is said in the [documentation](http://guides.rubygems.org/rubygems-org-api/#webhook-methods) 
> Specify * for the gem_name parameter to apply the hook globally to all gems.

As I understand it is not restricted by person's gems.

I have the following hook
```
Gems.web_hooks
=> {"all gems"=>[{"failure_count"=>0, "url"=>"https://gemns.herokuapp.com/hook"}]}
```
And today the hook was trigged with [unidom-party-china](https://rubygems.org/gems/unidom-party-china) and [sps-sub](https://rubygems.org/gems/sps-sub) gems, these gems are surely not mine ☺️