### PR TITLE
Fix obsolete params causing rubocop to exit, breaking travis ci

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,3 +74,13 @@ RaiseArgs:
 
 TrailingCommaInLiteral:
   Enabled: false
+
+# Ignore length of describe and context blocks
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*_spec.rb'
+
+# The RubyGems /api/v1/dependencies endpoint returns serialized ruby objects
+# that need to be deserialized within Gems::Client#dependencies. :(
+Security/MarshalLoad:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,11 +59,11 @@ EmptyLinesAroundAccessModifier:
 
 # Align ends correctly
 EndAlignment:
-  AlignWith: variable
+  EnforcedStyleAlignWith: variable
 
 # Indentation of when/else
 CaseIndentation:
-  IndentWhenRelativeTo: end
+  EnforcedStyle: end
   IndentOneStep: false
 
 Lambda:

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :test do
   gem 'backports'
   gem 'coveralls'
   gem 'rspec', '>= 3.1.0'
-  gem 'rubocop', '>= 0.27'
+  gem 'rubocop', '>= 0.50'
   gem 'simplecov', '>= 0.9'
   gem 'webmock'
   gem 'yardstick'

--- a/Rakefile
+++ b/Rakefile
@@ -28,4 +28,4 @@ Yardstick::Rake::Verify.new do |verify|
   verify.threshold = 68.7
 end
 
-task :default => [:spec, :rubocop, :verify_measurements]
+task :default => %i[spec rubocop verify_measurements]

--- a/gems.gemspec
+++ b/gems.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'gems/version'
@@ -9,11 +10,11 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Erik Michaels-Ober']
   spec.description   = 'Ruby wrapper for the RubyGems.org API'
   spec.email         = ['sferik@gmail.com']
-  spec.files         = %w(.yardopts CONTRIBUTING.md LICENSE.md README.md gems.gemspec) + Dir['lib/**/*.rb']
+  spec.files         = %w[.yardopts CONTRIBUTING.md LICENSE.md README.md gems.gemspec] + Dir['lib/**/*.rb']
   spec.homepage      = 'https://github.com/rubygems/gems'
-  spec.licenses      = %w(MIT)
+  spec.licenses      = %w[MIT]
   spec.name          = 'gems'
-  spec.require_paths = %w(lib)
+  spec.require_paths = %w[lib]
   spec.required_ruby_version = '>= 2.1.9'
   spec.summary       = spec.description
   spec.version       = Gems::VERSION

--- a/lib/gems/configuration.rb
+++ b/lib/gems/configuration.rb
@@ -5,12 +5,12 @@ require 'yaml'
 module Gems
   module Configuration
     # An array of valid keys in the options hash when configuring a {Gems::Client}
-    VALID_OPTIONS_KEYS = [
-      :host,
-      :key,
-      :password,
-      :user_agent,
-      :username,
+    VALID_OPTIONS_KEYS = %i[
+      host
+      key
+      password
+      user_agent
+      username
     ].freeze
 
     # Set the default API endpoint

--- a/lib/gems/request.rb
+++ b/lib/gems/request.rb
@@ -23,7 +23,7 @@ module Gems
   private
 
     def request(method, path, data, content_type, request_host = host) # rubocop:disable AbcSize, CyclomaticComplexity, MethodLength, ParameterLists, PerceivedComplexity
-      path += hash_to_query_string(data) if [:delete, :get].include? method
+      path += hash_to_query_string(data) if %i[delete get].include? method
       uri = URI.parse [request_host, path].join
       request_class = Net::HTTP.const_get method.to_s.capitalize
       request = request_class.new uri.request_uri
@@ -35,7 +35,7 @@ module Gems
       request.content_type = content_type
       case content_type
       when 'application/x-www-form-urlencoded'
-        request.form_data = data if [:post, :put].include? method
+        request.form_data = data if %i[post put].include? method
       when 'application/octet-stream'
         request.body = data
         request.content_length = data.size
@@ -59,9 +59,7 @@ module Gems
     def hash_to_query_string(hash)
       return '' if hash.empty?
 
-      hash.keys.each_with_object('?') do |key, query_string|
-        query_string << "#{URI.encode(key.to_s)}=#{URI.encode(hash[key])}&"
-      end.chop!
+      '?' + URI.encode_www_form(hash)
     end
 
     def body_from_response(response, method, content_type)


### PR DESCRIPTION
Rubocop is failing on Travis CI runs, causing pull requests to [show as failing](https://github.com/rubygems/gems/pull/39).  This is due to a couple configuration changes to rubocop introduced in https://github.com/bbatsov/rubocop/commit/022146a3b5a1eaa94a3f1d94785d1bd901f23845.

From https://travis-ci.org/rubygems/gems/jobs/275674793:
```
Finished in 0.2246 seconds (files took 0.33679 seconds to load)
52 examples, 0 failures

Randomized with seed 17455

Coverage report generated for RSpec to /home/travis/build/rubygems/gems/coverage. 164 / 164 LOC (100.0%) covered.
[Coveralls] Submitting to https://coveralls.io/api/v1
[Coveralls] Job #123.1
[Coveralls] https://coveralls.io/jobs/29383953
Coverage is at 100.0%.
Coverage report sent to Coveralls.
Running RuboCop...
Error: obsolete parameter IndentWhenRelativeTo (for Layout/CaseIndentation) found in /home/travis/build/rubygems/gems/.rubocop.yml
`IndentWhenRelativeTo` has been renamed to `EnforcedStyle`
obsolete parameter AlignWith (for Lint/EndAlignment) found in /home/travis/build/rubygems/gems/.rubocop.yml
`AlignWith` has been renamed to `EnforcedStyleAlignWith`
RuboCop failed!


The command "bundle exec rake" exited with 1.
```