### PR TITLE
Deal with JSON::ParserError for inquiring about nonexistent gems

### DIFF
--- a/lib/gems/client.rb
+++ b/lib/gems/client.rb
@@ -25,6 +25,8 @@ module Gems
     def info(gem_name)
       response = get("/api/v1/gems/#{gem_name}.json")
       JSON.parse(response)
+    rescue JSON::ParserError
+      []
     end
 
     # Returns an array of active gems that match the query

--- a/spec/gems/client_spec.rb
+++ b/spec/gems/client_spec.rb
@@ -21,7 +21,7 @@ describe Gems::Client do
     context 'when gem does not exist' do
       before do
         stub_get('/api/v1/gems/nonexistentgem.json').
-          to_return(:body => "This rubygem could not be found.")
+          to_return(:body => 'This rubygem could not be found.')
       end
       it 'returns some basic information about the given gem' do
         info = Gems.info 'nonexistentgem'

--- a/spec/gems/client_spec.rb
+++ b/spec/gems/client_spec.rb
@@ -6,14 +6,28 @@ describe Gems::Client do
   end
 
   describe '#info' do
-    before do
-      stub_get('/api/v1/gems/rails.json').
-        to_return(:body => fixture('rails.json'))
+    context 'when gem exists' do
+      before do
+        stub_get('/api/v1/gems/rails.json').
+          to_return(:body => fixture('rails.json'))
+      end
+      it 'returns some basic information about the given gem' do
+        info = Gems.info 'rails'
+        expect(a_get('/api/v1/gems/rails.json')).to have_been_made
+        expect(info['name']).to eq 'rails'
+      end
     end
-    it 'returns some basic information about the given gem' do
-      info = Gems.info 'rails'
-      expect(a_get('/api/v1/gems/rails.json')).to have_been_made
-      expect(info['name']).to eq 'rails'
+
+    context 'when gem does not exist' do
+      before do
+        stub_get('/api/v1/gems/nonexistentgem.json').
+          to_return(:body => "This rubygem could not be found.")
+      end
+      it 'returns some basic information about the given gem' do
+        info = Gems.info 'nonexistentgem'
+        expect(a_get('/api/v1/gems/nonexistentgem.json')).to have_been_made
+        expect(info).to eq []
+      end
     end
   end
 


### PR DESCRIPTION
If the gem we are looking for does not exist, RubyGems API returns
a string `This rubygem could not be found.` which is problematic
for the JSON parser.
This issue has been reported to rubygems.org.
rubygems/rubygems.org#1683

While we wait for rubygems.org to fix the API, we deal with
`JSON::ParserError` by rescuing it and returning an empty array.