### PR TITLE
Return same type after rescuing parser error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :test do
   gem 'backports'
   gem 'coveralls'
   gem 'rspec', '>= 3.1.0'
-  gem 'rubocop', '>= 0.50'
+  gem 'rubocop', '~> 0.52.1'
   gem 'simplecov', '>= 0.9'
   gem 'webmock'
   gem 'yardstick'

--- a/lib/gems/client.rb
+++ b/lib/gems/client.rb
@@ -26,7 +26,7 @@ module Gems
       response = get("/api/v1/gems/#{gem_name}.json")
       JSON.parse(response)
     rescue JSON::ParserError
-      []
+      {}
     end
 
     # Returns an array of active gems that match the query

--- a/spec/gems/client_spec.rb
+++ b/spec/gems/client_spec.rb
@@ -26,7 +26,7 @@ describe Gems::Client do
       it 'returns some basic information about the given gem' do
         info = Gems.info 'nonexistentgem'
         expect(a_get('/api/v1/gems/nonexistentgem.json')).to have_been_made
-        expect(info).to eq []
+        expect(info['name']).to be_nil
       end
     end
   end


### PR DESCRIPTION
This way Gems.info is guaranteed to return a Hash.

Fixes bug introduced in https://github.com/rubygems/gems/pull/41