### PR TITLE
Add very basic error support to Gems

### DIFF
--- a/lib/gems/request.rb
+++ b/lib/gems/request.rb
@@ -71,8 +71,10 @@ module Gems
         request(method, uri.request_uri, {}, content_type, host_with_scheme)
       when Net::HTTPNotFound
         raise Gems::NotFound.new(response.body)
-      else
+      when Net::HTTPSuccess
         response.body
+      else
+        raise Gems::GemError.new(response.body)
       end
     end
   end

--- a/spec/gems/request_spec.rb
+++ b/spec/gems/request_spec.rb
@@ -36,6 +36,20 @@ describe Gems::Request do
 
     it 'raise a Gems::NotFound error' do
       expect { Gems.dependencies('rails', 'thor') }.to raise_error(Gems::NotFound)
+    end
+  end
+
+  describe "#get with a non-200" do
+    before do
+      response_body = 'Internal Server Error'
+
+      stub_get('/api/v1/dependencies').
+        with(:query => {'gems' => 'rails,thor'}).
+        to_return(:body => response_body, :status => 500)
+    end
+
+    it 'raise a wrapped Gems::Error' do
+      expect { Gems.dependencies('rails', 'thor') }.to raise_error(Gems::GemError)
       expect(a_get('/api/v1/dependencies').with(:query => {'gems' => 'rails,thor'})).to have_been_made
     end
   end


### PR DESCRIPTION
Rather than returning a string when an error occurs, if a request is returned with something other than a 200 or other already-handled status code, we raise an error with the response body as the message.

This will prevent "silent failure" scenarios, and allow wrapping libraries to more easily handle error cases. 

Signed-off-by: Tom Duffield <tom@chef.io>