### PR TITLE
Add the supported version of Ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ implementations:
 * Ruby 2.5
 * Ruby 2.6
 * Ruby 2.7
+* Ruby 3.0
 * [JRuby][]
 
 [jruby]: https://www.jruby.org/


### PR DESCRIPTION
Ruby 3.0 is supported by Pull Requests that have been added in the past.

Reference: https://github.com/rubygems/gems/pull/58

---

Best regards,
s4na
