### PR TITLE
Bump required_ruby_version = ">= 2.3.0"

### DIFF
--- a/gems.gemspec
+++ b/gems.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/rubygems/gems'
   spec.licenses      = %w[MIT]
   spec.require_paths = %w[lib]
-  spec.required_ruby_version = '>= 2.1.9'
+  spec.required_ruby_version = '>= 2.3.0'
 end


### PR DESCRIPTION
The Ruby versions we support are [2.3 and above](https://github.com/rubygems/gems?tab=readme-ov-file#supported-ruby-versions). I will update the required_ruby_version. 