### PR TITLE
rdoc.info URL incorrectly redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Ruby wrapper for the RubyGems.org API.
     gem install gems
 
 ## Documentation
-[https://rdoc.info/gems/gems](https://rdoc.info/gems/gems)
+[https://www.rubydoc.info/gems/gems](https://www.rubydoc.info/gems/gems)
 
 # Usage Examples
 


### PR DESCRIPTION
The link to the documentation in the README (https://rdoc.info/gems/gems) results in a 301 Moved Permanently response that loops back to the same URL, causing excessive redirects:

```shell
curl -L https://rdoc.info/gems/gems -vvv
...
< HTTP/2 301
< location: https://rdoc.info/gems/gems
...
* Maximum (50) redirects followed
curl: (47) Maximum (50) redirects followed
```

This issue might be due to misconfigured Cloudflare page rules or nginx `.htaccess`, and/or we can update the link to https://www.rubydoc.info/gems/gems here, which I think is the correct URL.

