### PR TITLE
CI: Add Ruby 3.4 to matrix

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ 3.1, 3.2, 3.3, head ]
+        ruby: [ 3.1, 3.2, 3.3, 3.4, head ]
     steps:
       - uses: actions/checkout@v4
       - name: Setup ruby


### PR DESCRIPTION
This PR adds Ruby 3.4 to the build matrix.