### PR TITLE
Fix deserialization of user-controlled data

### DIFF
--- a/lib/gems/v1/client.rb
+++ b/lib/gems/v1/client.rb
@@ -291,8 +291,8 @@ module Gems
       # @example
       #   Gems.dependencies 'rails', 'thor'
       def dependencies(*gems)
-        response = get('/api/v1/dependencies', :gems => gems.join(','))
-        Marshal.load(response)
+        response = get('/api/v1/dependencies.json', :gems => gems.join(','))
+        JSON.parse(response)
       end
 
       # Returns an array of all the reverse dependencies to the given gem.


### PR DESCRIPTION
https://github.com/rubygems/gems/blob/ec5c7d0dd95d6fa15e4358022c5803c9281ad4bb/lib/gems/v1/client.rb#L294-L295

The best way to fix this problem is to avoid using `Marshal.load` on untrusted data. Instead, use a safe serialization format such as JSON or YAML (with safe loading), which do not allow arbitrary object instantiation. Since the `/api/v1/dependencies` endpoint is being called, we should check if the server can return the data in a safer format (such as JSON). If so, update the request to ask for JSON (e.g., by appending `.json` to the endpoint or setting the `Accept` header), and then use `JSON.parse` to safely deserialize the response. If the server only supports Marshal, then the only safe option is to refuse to process the data, as there is no safe way to use `Marshal.load` on untrusted input.

Assuming the server supports JSON (as it does for other endpoints in this code), the fix is:
- Change the endpoint in the `dependencies` method to request JSON (e.g., `/api/v1/dependencies.json`).
- Use `JSON.parse(response)` instead of `Marshal.load(response)` to safely parse the response.
- No additional dependencies are needed, as `json` is already required.

All changes are within `lib/gems/v1/client.rb`, specifically in the `dependencies` method.


#### References
- Ruby documentation: [guidance on deserializing objects safely](https://docs.ruby-lang.org/en/3.0.0/doc/security_rdoc.html)
- Ruby documentation: [security guidance on the Marshal library](https://ruby-doc.org/core-3.0.2/Marshal.html#module-Marshal-label-Security+considerations)
- Ruby documentation: [security guidance on JSON.load](https://ruby-doc.org/stdlib-3.0.2/libdoc/json/rdoc/JSON.html#method-i-load)
- Ruby documentation: [security guidance on the YAML library](https://ruby-doc.org/stdlib-3.0.2/libdoc/yaml/rdoc/YAML.html#module-YAML-label-Security)
- You can read that how unsafe yaml load methods can lead to code executions: [Universal Deserialisation Gadget for Ruby 2.x-3.x ](https://devcraft.io/2021/01/07/universal-deserialisation-gadget-for-ruby-2-x-3-x.html)
