### PR TITLE
docs: fix typo in comment (sepcific → specific)

### DIFF
--- a/lib/gems/v2/client.rb
+++ b/lib/gems/v2/client.rb
@@ -16,7 +16,7 @@ module Gems
         end
       end
 
-      # Returns information about the given gem for a sepcific version
+      # Returns information about the given gem for a specific version
       #
       # @authenticated false
       # @param gem_name [String] The name of a gem.


### PR DESCRIPTION
## Summary

Fix typo in `lib/gems/v2/client.rb`:
- `sepcific` → `specific`

No functional changes — comment only.